### PR TITLE
Fixing up the database

### DIFF
--- a/db/migrate/20160209011853_alter_players_remove_player_id_and_index.rb
+++ b/db/migrate/20160209011853_alter_players_remove_player_id_and_index.rb
@@ -1,0 +1,5 @@
+class AlterPlayersRemovePlayerIdAndIndex < ActiveRecord::Migration
+  def change
+    remove_column :players, :player_id
+  end
+end

--- a/db/migrate/20160209012935_alter_games_remove_game_id_column_and_index.rb
+++ b/db/migrate/20160209012935_alter_games_remove_game_id_column_and_index.rb
@@ -1,0 +1,5 @@
+class AlterGamesRemoveGameIdColumnAndIndex < ActiveRecord::Migration
+  def change
+    remove_column :games, :game_id
+  end
+end

--- a/db/migrate/20160209013148_alter_games_add_indexes_for_white_and_black_players.rb
+++ b/db/migrate/20160209013148_alter_games_add_indexes_for_white_and_black_players.rb
@@ -1,0 +1,6 @@
+class AlterGamesAddIndexesForWhiteAndBlackPlayers < ActiveRecord::Migration
+  def change
+    add_index :games, :white_player_id
+    add_index :games, :black_player_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,20 +11,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160206224408) do
+ActiveRecord::Schema.define(version: 20160209013148) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "games", force: true do |t|
-    t.integer  "game_id"
     t.integer  "white_player_id"
     t.integer  "black_player_id"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  add_index "games", ["game_id"], name: "index_games_on_game_id", using: :btree
+  add_index "games", ["black_player_id"], name: "index_games_on_black_player_id", using: :btree
+  add_index "games", ["white_player_id"], name: "index_games_on_white_player_id", using: :btree
 
   create_table "pieces", force: true do |t|
     t.string   "type"
@@ -42,15 +42,12 @@ ActiveRecord::Schema.define(version: 20160206224408) do
   add_index "pieces", ["player_id"], name: "index_pieces_on_player_id", using: :btree
 
   create_table "players", force: true do |t|
-    t.integer  "player_id"
     t.string   "name"
     t.integer  "wins"
     t.integer  "losses"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
-
-  add_index "players", ["player_id"], name: "index_players_on_player_id", using: :btree
 
   create_table "users", force: true do |t|
     t.string   "email",                  default: "", null: false


### PR DESCRIPTION
- Adds a migration to remove the player_id column from players and also removes the corrisponding index
- Adds a migration to remove the game_id column from games and also removes the corrisponding index
- Adds a migration to add indexes for both white_player_id and black_player_id

**Notes and Questions**
- I wasn't sure if all the changes should be in one migration file or if it's better to split it up. I ended up splitting it up since that seemed to make it more clear what was going on in each migration. Is it better to have lots of little mirgrations like that or would it have been better just to put it all into one file?
