### PR TITLE
Attempt at pawn valid_move?

### DIFF
--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -6,4 +6,48 @@ class Pawn < Piece
       'o'
     end
   end
+
+  def valid_move?(destination_row, destination_column)
+    move = [destination_row - row, destination_column - column]
+
+    move[0] *= -1 if white?
+
+    if move == FORWARD_ONE
+      return space_unoccupied?(destination_row, destination_column)
+    elsif move == FORWARD_TWO && in_starting_row?
+      return space_unoccupied?(destination_row, destination_column)
+    elsif CAPTURE_MOVES.include?(move)
+      return can_capture?(destination_row, destination_column)
+    end
+
+    false
+  end
+
+  private
+
+  FORWARD_ONE = [1, 0].freeze
+  FORWARD_TWO = [2, 0].freeze
+  CAPTURE_MOVES = [[1, 1], [1, -1]].freeze
+
+  def in_starting_row?
+    return row == 6 if white?
+
+    row == 1
+  end
+
+  def opposite_color
+    if white?
+      'black'
+    else
+      'white'
+    end
+  end
+
+  def space_unoccupied?(destination_row, destination_column)
+    !game.pieces.where(row: destination_row, column: destination_column).exists?
+  end
+
+  def can_capture?(destination_row, destination_column)
+    game.pieces.where(row: destination_row, column: destination_column, color: opposite_color).exists?
+  end
 end

--- a/spec/factories/pawn_factory.rb
+++ b/spec/factories/pawn_factory.rb
@@ -1,0 +1,19 @@
+FactoryGirl.define do
+  factory :black_pawn, parent: :piece, class: 'Pawn' do
+    row 1
+    column 4
+    in_game true
+    color 'black'
+    association :player
+    association :game
+  end
+
+  factory :white_pawn, parent: :piece, class: 'Pawn' do
+    row 6
+    column 4
+    in_game true
+    color 'white'
+    association :player
+    association :game
+  end
+end

--- a/spec/models/pawn_spec.rb
+++ b/spec/models/pawn_spec.rb
@@ -1,0 +1,79 @@
+require 'rails_helper'
+
+RSpec.describe Pawn, type: :model do
+  before do
+    # Note: We want the board to be emptry for this test.
+    allow_any_instance_of(Game).to receive(:populate_board!).and_return true
+  end
+
+  describe '#valid_move?' do
+    it 'returns true when pawn moves to an empty space two spaces forward if it is the first move' do
+      pawn = FactoryGirl.create(:black_pawn)
+
+      expect(pawn.valid_move?(3, 4)).to eq(true)
+    end
+
+    it 'returns false if trying to move two spaces forward and it is not the first move' do
+      pawn = FactoryGirl.create(:white_pawn, row: 5)
+
+      expect(pawn.valid_move?(3, 4)).to eq(false)
+    end
+
+    it 'returns true when pawn moves to empty space one space forward' do
+      pawn = FactoryGirl.create(:black_pawn, row: 3)
+
+      expect(pawn.valid_move?(4, 4)).to eq(true)
+    end
+
+    it 'returns false if pawn is trying to capture vertically' do
+      pawn = FactoryGirl.create(:white_pawn)
+      FactoryGirl.create(:piece, row: 4, column: 4, color: 'black', game: pawn.game)
+
+      expect(pawn.valid_move?(4, 4)).to eq(false)
+    end
+
+    it 'returns false if pawn tries moving to a space occupied by a piece of the same color' do
+      pawn = FactoryGirl.create(:black_pawn)
+      FactoryGirl.create(:piece, row: 2, column: 4, color: 'black', game: pawn.game)
+
+      expect(pawn.valid_move?(2, 4)).to eq(false)
+    end
+
+    it 'returns true when pawn moves diagonally one space forward to capture a piece' do
+      pawn = FactoryGirl.create(:white_pawn)
+      FactoryGirl.create(:piece, row: 5, column: 5, color: 'black', game: pawn.game)
+
+      expect(pawn.valid_move?(5, 5)).to eq(true)
+    end
+
+    it 'returns false when pawn tries to move diagonally when not capturing another piece' do
+      pawn = FactoryGirl.create(:black_pawn)
+
+      expect(pawn.valid_move?(2, 5)).to eq(false)
+    end
+
+    it 'always returns false when pawn tries moving horizontally' do
+      pawn = FactoryGirl.create(:white_pawn)
+
+      expect(pawn.valid_move?(6, 5)).to eq(false)
+    end
+
+    it 'always returns false when pawn tries moving backwards' do
+      pawn = FactoryGirl.create(:black_pawn)
+
+      expect(pawn.valid_move?(0, 4)).to eq(false)
+    end
+
+    it 'always returns false when trying to move forward more than two spaces' do
+      pawn = FactoryGirl.create(:white_pawn)
+
+      expect(pawn.valid_move?(2, 4)).to eq(false)
+    end
+
+    it 'always returns false when trying to move diagonally more than one space' do
+      pawn = FactoryGirl.create(:black_pawn)
+
+      expect(pawn.valid_move?(3, 6)).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
- Adds valid_move? method to the pawn model
- Adds specs new spec for pawn model which includes specs for the valid_move? method
- Adds a pawn factory that creates both white and black pawns for specs

Notes and Questions:
- Feels a little clunky, feel like there is probably a cleaner way to do it
- Probably could combine forward_one and forward_two stuff in a better way but not sure how
