### PR TITLE
Bishop valid move

### DIFF
--- a/app/models/bishop.rb
+++ b/app/models/bishop.rb
@@ -1,9 +1,34 @@
 class Bishop < Piece
+  def valid_move?(destination_row, destination_column)
+    if diagonal?(destination_row, destination_column)
+      return true if capturable?(destination_row, destination_column) || (unobstructed?(destination_row, destination_column) && unoccupied_space?(destination_row, destination_column))
+      return false
+    end
+    false
+  end
+
+  def unobstructed?(destination_row, destination_column)
+    return true unless obstructed?(destination_row, destination_column)
+    false
+  end
+
+  def unoccupied_space?(destination_row, destination_column)
+    return true unless occupied_space?(destination_row, destination_column)
+
+    false
+  end
+
   def chess_font_character
     if white?
       'b'
     else
       'v'
     end
+  end
+
+  private
+
+  def diagonal?(destination_row, destination_column)
+    (row - destination_row).abs == (column - destination_column).abs
   end
 end

--- a/app/models/bishop.rb
+++ b/app/models/bishop.rb
@@ -2,20 +2,16 @@ class Bishop < Piece
   def valid_move?(destination_row, destination_column)
     if diagonal?(destination_row, destination_column)
       return true if capturable?(destination_row, destination_column) || (unobstructed?(destination_row, destination_column) && unoccupied_space?(destination_row, destination_column))
-      return false
     end
     false
   end
 
   def unobstructed?(destination_row, destination_column)
-    return true unless obstructed?(destination_row, destination_column)
-    false
+    !obstructed?(destination_row, destination_column)
   end
 
   def unoccupied_space?(destination_row, destination_column)
-    return true unless occupied_space?(destination_row, destination_column)
-
-    false
+    !occupied_space?(destination_row, destination_column)
   end
 
   def chess_font_character

--- a/spec/factories/bishop_factory.rb
+++ b/spec/factories/bishop_factory.rb
@@ -1,0 +1,19 @@
+FactoryGirl.define do
+  factory :white_bishop, parent: :piece, class: 'Bishop' do
+    row 0
+    column 2
+    color 'white'
+    in_game true
+    association :player
+    association :game
+  end
+
+  factory :black_bishop, parent: :piece, class: 'Bishop' do
+    row 4
+    column 6
+    in_game true
+    color 'black'
+    association :player
+    association :game
+  end
+end

--- a/spec/models/bishop_spec.rb
+++ b/spec/models/bishop_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe Bishop, type: :model do
+  before do
+    # Note: We want the board to be emptry for this test.
+    allow_any_instance_of(Game).to receive(:populate_board!).and_return true
+  end
+
+  describe '#valid_move?' do
+    before :each do
+      @game = FactoryGirl.create(:game)
+      @white_bishop = FactoryGirl.create(:white_bishop, game: @game)
+      @black_bishop = FactoryGirl.create(:black_bishop, game: @white_bishop.game)
+    end
+    it 'returns true when bishop moves diagonal three spaces.' do
+      expect(@white_bishop.valid_move?(3, 5)).to eq(true)
+    end
+
+    it 'returns true when trying to move to an opponents piece' do
+      expect(@white_bishop.valid_move?(4, 6)).to eq(true)
+    end
+
+    it 'return false when move is invalid' do
+      expect(@white_bishop.valid_move?(1, 5)).to eq(false)
+    end
+
+    it 'returns false when piece is obstructed?' do
+      FactoryGirl.create(:piece, row: 1, column: 3, color: 'white', game: @white_bishop.game)
+      expect(@white_bishop.valid_move?(1, 3)).to eq(false)
+    end
+  end
+end

--- a/spec/models/bishop_spec.rb
+++ b/spec/models/bishop_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Bishop, type: :model do
     before :each do
       @game = FactoryGirl.create(:game)
       @white_bishop = FactoryGirl.create(:white_bishop, game: @game)
-      @black_bishop = FactoryGirl.create(:black_bishop, game: @white_bishop.game)
+      @black_bishop = FactoryGirl.create(:black_bishop, game: @game)
     end
     it 'returns true when bishop moves diagonal three spaces.' do
       expect(@white_bishop.valid_move?(3, 5)).to eq(true)
@@ -25,7 +25,7 @@ RSpec.describe Bishop, type: :model do
     end
 
     it 'returns false when piece is obstructed?' do
-      FactoryGirl.create(:piece, row: 1, column: 3, color: 'white', game: @white_bishop.game)
+      FactoryGirl.create(:piece, row: 1, column: 3, color: 'white', game: @game)
       expect(@white_bishop.valid_move?(1, 3)).to eq(false)
     end
   end


### PR DESCRIPTION
Introduced the valid_move? method for the Bishop.
New tests are also introduced that validates this new method.

The tests verify that the Bishop is only able to move in diagonally unobstructed? or capturable? paths.
