### PR TITLE
Refactoring and bug fixes for pieces

### DIFF
--- a/app/models/bishop.rb
+++ b/app/models/bishop.rb
@@ -1,17 +1,9 @@
 class Bishop < Piece
   def valid_move?(destination_row, destination_column)
-    if diagonal?(destination_row, destination_column)
-      return true if capturable?(destination_row, destination_column) || (unobstructed?(destination_row, destination_column) && unoccupied_space?(destination_row, destination_column))
+    if moving_diagonally?(destination_row, destination_column)
+      return true if (capturable?(destination_row, destination_column) || unoccupied_space?(destination_row, destination_column)) && unobstructed?(destination_row, destination_column)
     end
     false
-  end
-
-  def unobstructed?(destination_row, destination_column)
-    !obstructed?(destination_row, destination_column)
-  end
-
-  def unoccupied_space?(destination_row, destination_column)
-    !occupied_space?(destination_row, destination_column)
   end
 
   def chess_font_character
@@ -20,11 +12,5 @@ class Bishop < Piece
     else
       'v'
     end
-  end
-
-  private
-
-  def diagonal?(destination_row, destination_column)
-    (row - destination_row).abs == (column - destination_column).abs
   end
 end

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -13,9 +13,9 @@ class Pawn < Piece
     move[0] *= -1 if white?
 
     if move == FORWARD_ONE
-      return !occupied_space?(destination_row, destination_column)
-    elsif move == FORWARD_TWO && first_move?
-      return !occupied_space?(destination_row, destination_column)
+      return unoccupied_space?(destination_row, destination_column)
+    elsif move == FORWARD_TWO
+      return can_move_two?(destination_row, destination_column)
     elsif CAPTURE_MOVES.include?(move)
       return capturable?(destination_row, destination_column)
     end
@@ -31,5 +31,9 @@ class Pawn < Piece
 
   def first_move?
     created_at == updated_at
+  end
+
+  def can_move_two?(destination_row, destination_column)
+    first_move? && unoccupied_space?(destination_row, destination_column) && unobstructed?(destination_row, destination_column)
   end
 end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -61,13 +61,13 @@ class Piece < ActiveRecord::Base
     end
   end
 
-  private
+  def unoccupied_space?(destination_row, destination_column)
+    !occupied_space?(destination_row, destination_column)
+  end
 
-  NONE = 0
-  UP = 1
-  DOWN = -1
-  RIGHT = 1
-  LEFT = -1
+  def unobstructed?(destination_row, destination_column)
+    !obstructed?(destination_row, destination_column)
+  end
 
   def moving_horizontally?(destination_row)
     row == destination_row
@@ -81,16 +81,24 @@ class Piece < ActiveRecord::Base
     (row - destination_row).abs == (column - destination_column).abs
   end
 
+  private
+
+  NONE = 0
+  UP = -1
+  DOWN = 1
+  RIGHT = 1
+  LEFT = -1
+
   def moving_up_and_to_the_right?(destination_row, destination_column)
-    row < destination_row && column < destination_column
+    row > destination_row && column < destination_column
   end
 
   def moving_up_and_to_the_left?(destination_row, destination_column)
-    row < destination_row && column > destination_column
+    row > destination_row && column > destination_column
   end
 
   def moving_down_and_to_the_right?(destination_row, destination_column)
-    row > destination_row && column < destination_column
+    row < destination_row && column < destination_column
   end
 
   def horizontal_obstructed?(destination_column)
@@ -100,19 +108,19 @@ class Piece < ActiveRecord::Base
   end
 
   def vertical_obstructed?(destination_row)
-    return check_path(UP, NONE, destination_row - row) if row < destination_row
+    return check_path(UP, NONE, row - destination_row) if row > destination_row
 
-    check_path(DOWN, NONE, row - destination_row)
+    check_path(DOWN, NONE, destination_row - row)
   end
 
   def diagonal_obstructed?(destination_row, destination_column)
-    return check_path(UP, RIGHT, destination_row - row) if moving_up_and_to_the_right?(destination_row, destination_column)
+    return check_path(UP, RIGHT, row - destination_row) if moving_up_and_to_the_right?(destination_row, destination_column)
 
-    return check_path(UP, LEFT, destination_row - row) if moving_up_and_to_the_left?(destination_row, destination_column)
+    return check_path(UP, LEFT, row - destination_row) if moving_up_and_to_the_left?(destination_row, destination_column)
 
-    return check_path(DOWN, RIGHT, row - destination_row) if moving_down_and_to_the_right?(destination_row, destination_column)
+    return check_path(DOWN, RIGHT, destination_row - row) if moving_down_and_to_the_right?(destination_row, destination_column)
 
-    check_path(DOWN, LEFT, row - destination_row)
+    check_path(DOWN, LEFT, destination_row - row)
   end
 
   def check_path(row_direction, col_direction, distance)

--- a/app/models/queen.rb
+++ b/app/models/queen.rb
@@ -1,27 +1,14 @@
 class Queen < Piece
   def valid_move?(destination_row, destination_column)
-    if legal_path?(destination_row, destination_column) && not_obstructed?(destination_row, destination_column)
-      return true if piece_present?(destination_row, destination_column) && opponent_piece?(destination_row, destination_column)
+    if legal_path?(destination_row, destination_column) && unobstructed?(destination_row, destination_column)
+      return true if unoccupied_space?(destination_row, destination_column) || capturable?(destination_row, destination_column)
       return false
     end
     false
   end
 
-  def opponent_piece?(destination_row, destination_column)
-    game.pieces.find_by(row: destination_row, column: destination_column).color != color
-  end
-
-  def piece_present?(destination_row, destination_column)
-    game.pieces.find_by(row: destination_row, column: destination_column).present?
-  end
-
   def legal_path?(destination_row, destination_column)
     moving_horizontally?(destination_row) || moving_vertically?(destination_column) || moving_diagonally?(destination_row, destination_column)
-  end
-
-  def not_obstructed?(destination_row, destination_column)
-    return false if obstructed?(destination_row, destination_column)
-    true
   end
 
   def chess_font_character
@@ -30,19 +17,5 @@ class Queen < Piece
     else
       'w'
     end
-  end
-
-  private
-
-  def moving_horizontally?(destination_row)
-    row == destination_row
-  end
-
-  def moving_vertically?(destination_column)
-    column == destination_column
-  end
-
-  def moving_diagonally?(destination_row, destination_column)
-    (row - destination_row).abs == (column - destination_column).abs
   end
 end

--- a/app/models/rook.rb
+++ b/app/models/rook.rb
@@ -1,17 +1,9 @@
 class Rook < Piece
   def valid_move?(destination_row, destination_column)
-    if vertical?(destination_column) || horizontal?(destination_row)
-      return true if capturable?(destination_row, destination_column) || (unobstructed?(destination_row, destination_column) && unoccupied_space?(destination_row, destination_column))
+    if moving_vertically?(destination_column) || moving_horizontally?(destination_row)
+      return true if (capturable?(destination_row, destination_column) || unoccupied_space?(destination_row, destination_column)) && unobstructed?(destination_row, destination_column)
     end
     false
-  end
-
-  def unobstructed?(destination_row, destination_column)
-    !obstructed?(destination_row, destination_column)
-  end
-
-  def unoccupied_space?(destination_row, destination_column)
-    !occupied_space?(destination_row, destination_column)
   end
 
   def chess_font_character
@@ -20,15 +12,5 @@ class Rook < Piece
     else
       't'
     end
-  end
-
-  private
-
-  def horizontal?(destination_row)
-    row == destination_row
-  end
-
-  def vertical?(destination_column)
-    column == destination_column
   end
 end

--- a/spec/models/bishop_spec.rb
+++ b/spec/models/bishop_spec.rb
@@ -28,5 +28,10 @@ RSpec.describe Bishop, type: :model do
       FactoryGirl.create(:piece, row: 1, column: 3, color: 'white', game: @game)
       expect(@white_bishop.valid_move?(1, 3)).to eq(false)
     end
+
+    it 'returns false when trying to capture a piece while path is obstructed' do
+      FactoryGirl.create(:piece, row: 1, column: 3, color: 'white', game: @game)
+      expect(@white_bishop.valid_move?(4, 6)).to eq(false)
+    end
   end
 end

--- a/spec/models/pawn_spec.rb
+++ b/spec/models/pawn_spec.rb
@@ -7,10 +7,17 @@ RSpec.describe Pawn, type: :model do
   end
 
   describe '#valid_move?' do
-    it 'returns true when pawn moves to an empty space two spaces forward if it is the first move' do
+    it 'returns true when pawn moves to an empty space two spaces forward if it is the first move and unobstructed' do
       pawn = FactoryGirl.create(:black_pawn)
 
       expect(pawn.valid_move?(3, 4)).to eq(true)
+    end
+
+    it 'returns false when pawn moves to an empty space two spaces forward if it is the first move and the path is obstructed' do
+      pawn = FactoryGirl.create(:black_pawn)
+      FactoryGirl.create(:black_pawn, row: 2, column: 4, game: pawn.game)
+
+      expect(pawn.valid_move?(3, 4)).to eq(false)
     end
 
     it 'returns false if trying to move two spaces forward and it is not the first move' do

--- a/spec/models/queen_spec.rb
+++ b/spec/models/queen_spec.rb
@@ -7,64 +7,35 @@ RSpec.describe Queen, type: :model do
       allow_any_instance_of(Game).to receive(:populate_board!).and_return true
     end
 
-    it 'return true if pieces is opponent' do
-      game = FactoryGirl.create(:game)
-      queen = FactoryGirl.create(:queen, game: game)
-      FactoryGirl.create(:piece, row: 2, column: 5, color: 'black', game: queen.game)
-      expect(queen.opponent_piece?(2, 5)).to eq(true)
-    end
+    let!(:game) { FactoryGirl.create(:game) }
+    let!(:queen) { FactoryGirl.create(:queen, game: game) }
 
-    it 'return true if pieces is present' do
-      game = FactoryGirl.create(:game)
-      queen = FactoryGirl.create(:queen, game: game)
-      FactoryGirl.create(:piece, row: 1, column: 3, color: 'black', game: queen.game)
-      expect(queen.piece_present?(1, 3)).to eq(true)
-    end
-
-    it 'return false if pieces is not present' do
-      game = FactoryGirl.create(:game)
-      queen = FactoryGirl.create(:queen, game: game)
-      expect(queen.piece_present?(3, 3)).to eq(false)
-    end
-
-    it 'return false if not not_obstructed?(path obstructed)' do
-      game = FactoryGirl.create(:game)
-      queen = FactoryGirl.create(:queen, game: game)
-      FactoryGirl.create(:piece, row: 0, column: 5, game: game)
-      expect(queen.not_obstructed?(0, 6)).to eq(false)
-    end
-
-    it 'return true if not_obstructed? (path clear) ' do
-      game = FactoryGirl.create(:game)
-      queen = FactoryGirl.create(:queen, row: 0, column: 3, game: game)
-      expect(queen.not_obstructed?(3, 0)).to eq(true)
-    end
-
-    it 'return obstructed? true' do
-      game = FactoryGirl.create(:game)
-      queen = FactoryGirl.create(:queen, game: game)
-      FactoryGirl.create(:piece, row: 2, column: 5, game: queen.game)
-      expect(queen.obstructed?(4, 7)).to eq(true)
-    end
-
-    it 'return true for valid move' do
-      game = FactoryGirl.create(:game)
-      queen = FactoryGirl.create(:queen, game: game)
+    it 'return true if capturing an opponent' do
       FactoryGirl.create(:piece, row: 2, column: 5, color: 'black', game: queen.game)
       expect(queen.valid_move?(2, 5)).to eq(true)
     end
 
-    it 'return false for not valid move' do
-      game = FactoryGirl.create(:game)
-      queen = FactoryGirl.create(:queen, game: game)
+    it 'return true if not_obstructed? (path clear) ' do
+      expect(queen.valid_move?(3, 0)).to eq(true)
+    end
+
+    it 'return false if path is obstructed' do
       FactoryGirl.create(:piece, row: 2, column: 5, color: 'black', game: queen.game)
-      expect(queen.valid_move?(2, 6)).to eq(false)
+      expect(queen.valid_move?(3, 6)).to eq(false)
     end
 
     it 'return false because destination has our pieces' do
-      game = FactoryGirl.create(:game)
-      queen = FactoryGirl.create(:queen, game: game)
       FactoryGirl.create(:piece, row: 2, column: 5, color: 'white', game: queen.game)
+      expect(queen.valid_move?(2, 5)).to eq(false)
+    end
+
+    it 'returns false if move is not a legal path' do
+      expect(queen.valid_move?(2, 4)).to eq(false)
+    end
+
+    it 'returns false if trying to capture an opponent while path is obstructed' do
+      FactoryGirl.create(:white_pawn, row: 1, column: 4, game: game)
+      FactoryGirl.create(:piece, row: 2, column: 5, color: 'black', game: game)
       expect(queen.valid_move?(2, 5)).to eq(false)
     end
   end

--- a/spec/models/rook_spec.rb
+++ b/spec/models/rook_spec.rb
@@ -32,5 +32,10 @@ RSpec.describe Rook, type: :model do
       FactoryGirl.create(:piece, row: 0, column: 3, color: 'white', game: @game)
       expect(@white_rook.valid_move?(0, 5)).to eq(false)
     end
+
+    it 'returns false when trying to capture a piece while path is obstructed' do
+      FactoryGirl.create(:piece, row: 0, column: 3, color: 'white', game: @game)
+      expect(@white_rook.valid_move?(0, 7)).to eq(false)
+    end
   end
 end


### PR DESCRIPTION
So a littel bit about how all these changes came about, I in process of switching over to another one of my cards for this week and decided just to play around with the game. While playing around with moving pieces and such I noticed there was a bug with some of the pawn valid_move? code, more specifically I forgotten to check for any obstructions when the pawn moves forward two spaces. So I started to look into the problem and in the process decided to look as some of the other valid_moves? for other pieces to just kind of curious to see what everyone else was doing of checking for obstructions. In the process of doing this I began to see there were a few similar if not identical methods across the different pieces which seemed like a good opportunity to DRY things up little. Anyway, this kind of set me off on a testing cleaning rampage so I decided to play  around with the game a bit more to see what other things I might have overlooked, one thing lead to another and here we are with these changes

I don't want to be 'that guy', so if feel free to ignore these changes, make suggestions or cherry pick which ones you would like to use all feed back is welcome :)

**Changes:**
- DRYes up different piece type code a little bit by creating unobstructed? and unoccupied_space? and making the moving_xxlly methods protected instead of private in piece.rb so that all the other types can use them
- Refactores some of the different piece type's valid_move? methods to use the new unobstructed? and unoccupied_space? methods as well as using piece.rb versions of moving_xxlly
- Fixes problem of pawns being able to move through other pieces when trying to move forward two spaces, this is now considered in valid (as it should've been in the first place :) )
- Adds can_move_two? method to pawn.rb to clean things up a little
- Finally did some clean up on the obstructed? code since I had originally written it with the idea that (0,0) would be in the bottom left when in reality (0,0) is in the top right so had to fix a little bit of the naming and logic (probably a dumb idea to potentially break a lot of logic in diffrent places just to make it the naming is correct but if tests are to be believed, everything is still working)
- Found a odd behavior for rook and bishop, couldn't move to unoccupied spaces if the path was obstructed however, they could still capture pieces even if the path was obstructed, ended having to slightly alter the logic in those two pieces valid_move? methods
- I also added tests to rook, bishop and queen to make sure that none of them should be able to capture a piece if their path is blocked
- I also noticed that the queen couldn't move to an unoccupied location so made a slight change to that logic as well to fix that issue
- Ended making some changes to queen_spec.rb due to other changes, took out tests that were testing the helper methods that are now or already were a part of piece.rb and also added a couple new ones

Ok I think that about covers it. Again I understand I went a little crazy on this and maybe got a little ahead of myself and or oversteped my bounds so if you guys have any opinions on these changes one way or another please let me know!
