### PR TITLE
changed games_controller to make sure user is logged in, may want to …

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,4 +1,5 @@
 class GamesController < ApplicationController
+  before_action :authenticate_user!
   before_action :set_game, only: [:show, :edit, :update, :destroy]
 
   # GET /games


### PR DESCRIPTION
…consider changing this to show the index and only prompt user sign in for joining an actual game

Unsure how we want to do this, Mike, as in, I'm not sure when the best time to prompt a user to sign in is. Should the prompt be when joining an actual "board" or, should only authenticated users be able to view the games index? 

The reason why I added this to the games_controller was because the games_index was calling upon the current_user id, simply causing the app to break. pls advise :)
