### PR TITLE
Pass turn implement for after moving a piece

### DIFF
--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -3,9 +3,12 @@ class PiecesController < ApplicationController
     row = pieces_params[:row].to_i
     column = pieces_params[:column].to_i
 
-    render(nothing: true, status: :ok) && return if current_piece.move_to!(row, column)
-
-    render nothing: true, status: :bad_request
+    if current_piece.move_to!(row, column)
+      current_piece.game.pass_turn(current_piece.game.active_player)
+      render(nothing: true, status: :ok)
+    else
+      render nothing: true, status: :bad_request
+    end
   end
 
   private

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -3,6 +3,7 @@ class Game < ActiveRecord::Base
   belongs_to  :white_player, class_name: 'User'
   belongs_to  :black_player, class_name: 'User'
   belongs_to  :winning_player, class_name: 'User'
+  belongs_to  :active_player, class_name: 'User'
 
   after_create :populate_board!
 
@@ -30,5 +31,9 @@ class Game < ActiveRecord::Base
 
   def other_player(player)
     player == white_player ? black_player.id : white_player.id
+  end
+
+  def pass_turn(player)
+    update_attributes(active_player_id: other_player(player))
   end
 end

--- a/db/migrate/20160308010715_change_add_column_ative_player_id_to_games.rb
+++ b/db/migrate/20160308010715_change_add_column_ative_player_id_to_games.rb
@@ -1,0 +1,6 @@
+class ChangeAddColumnAtivePlayerIdToGames < ActiveRecord::Migration
+  def change
+    add_column :games, :active_player_id, :integer
+    add_index :games, :active_player_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160307210809) do
+ActiveRecord::Schema.define(version: 20160308010715) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,8 +23,10 @@ ActiveRecord::Schema.define(version: 20160307210809) do
     t.datetime "updated_at"
     t.integer  "winning_player_id"
     t.boolean  "over"
+    t.integer  "active_player_id"
   end
 
+  add_index "games", ["active_player_id"], name: "index_games_on_active_player_id", using: :btree
   add_index "games", ["black_player_id"], name: "index_games_on_black_player_id", using: :btree
   add_index "games", ["white_player_id"], name: "index_games_on_white_player_id", using: :btree
   add_index "games", ["winning_player_id"], name: "index_games_on_winning_player_id", using: :btree

--- a/spec/controllers/pieces_controller_spec.rb
+++ b/spec/controllers/pieces_controller_spec.rb
@@ -34,5 +34,14 @@ RSpec.describe PiecesController, type: :controller do
 
       expect(response).to have_http_status(:bad_request)
     end
+
+    it 'passes the turn for a valid move' do
+      game.active_player = game.black_player
+      put :update, id: black_pawn.id, piece: { row: 3, column: 4 }
+
+      game.reload
+
+      expect(game.active_player).to eq(game.white_player)
+    end
   end
 end

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -63,4 +63,15 @@ RSpec.describe Game, type: :model do
       expect(game.over).to eq(true)
     end
   end
+
+  describe '#pass_turn' do
+    let(:game) { FactoryGirl.create(:game) }
+
+    it 'ends the current_player\'s turn and passes the turn the the other player' do
+      game.active_player = game.white_player
+
+      game.pass_turn(game.white_player)
+      expect(game.active_player).to eq(game.black_player)
+    end
+  end
 end


### PR DESCRIPTION
- Adds ative_player_id to the games to keep track of who's turn it is
- Adds pass_turn method to the game model that sets the sets the active player to the other player
- Piece controller now passes the turn to the other player after the current active player moves a piece
